### PR TITLE
feat: add id-token permission for OIDC in npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,6 +8,7 @@ on:
     types: [created]
 
 permissions:
+  id-token: write  # Required for OIDC
   contents: read
 
 jobs:


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->
Add id-token permission for OIDC in npm publish workflow

## Changes

<!-- List the key changes made -->
Added id-token permission for OIDC in npm publish workflow
- 

## Related Issues

<!-- Link any related issues: Closes #123, Fixes #456 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Checklist

- [x] My code follows the existing code style
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] The build succeeds (`npm run build`)
- [x] I have updated the documentation (if applicable)
